### PR TITLE
#34: Download metarpheus.jar only before running the scripts (closes #34)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "preversion": "npm run lint",
     "prepublish": "npm run build",
-    "postinstall": "node lib/postinstall",
     "release-version": "smooth-release"
   },
   "repository": {
@@ -57,7 +56,9 @@
     "eslint": "^3.9.1",
     "eslint-config-buildo": "github:buildo/eslint-config",
     "metarpheus-tcomb": "0.2.0",
+    "progress": "^1.1.8",
     "request": "^2.75.0",
+    "request-promise": "^4.1.1",
     "stylelint": "^7.5.0",
     "stylelint-config-buildo": "0.0.2"
   }

--- a/src/postinstall.js
+++ b/src/postinstall.js
@@ -1,3 +1,0 @@
-import download from './scripts/metarpheus/download';
-
-download();

--- a/src/scripts/metarpheus-diff/index.js
+++ b/src/scripts/metarpheus-diff/index.js
@@ -4,57 +4,62 @@ import { green, red } from 'chalk';
 import metarpheusTcombConfig from '../metarpheus/config';
 import runMetarpheusTcomb from '../metarpheus/run';
 import { logger } from '../../util';
+import download from '../metarpheus/download';
 
-const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
+download()
+  .then(() => {
 
-const parseDiffsAcc = {
-  output: '\n',
-  exitCode: 0
-};
+    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
 
-function getExitCode(part, exitCode) {
-  if (part.added || part.removed) {
-    return 1;
-  }
-  return exitCode;
-}
+    const parseDiffsAcc = {
+      output: '\n',
+      exitCode: 0
+    };
 
-function buildOutput(part) {
-  if (part.added || part.removed) {
-    const color = part.added ? green : red;
-    return color(part.value);
-  }
-  return '';
-}
+    function getExitCode(part, exitCode) {
+      if (part.added || part.removed) {
+        return 1;
+      }
+      return exitCode;
+    }
 
-function parseDiffs({ output, exitCode }, part) {
-  return {
-    exitCode: getExitCode(part, exitCode),
-    output: output + buildOutput(part)
-  };
-}
+    function buildOutput(part) {
+      if (part.added || part.removed) {
+        const color = part.added ? green : red;
+        return color(part.value);
+      }
+      return '';
+    }
+
+    function parseDiffs({ output, exitCode }, part) {
+      return {
+        exitCode: getExitCode(part, exitCode),
+        output: output + buildOutput(part)
+      };
+    }
+
+    // API diff
+    logger.metarpheusDiff('Diffing api files...');
+    const {
+      output: apiOutput,
+      exitCode: apiExitCode
+    } = diffLines(fs.readFileSync(metarpheusTcombConfig.apiOut, 'utf-8'), api)
+      .reduce(parseDiffs, parseDiffsAcc);
+
+    process.stdout.write(apiOutput);
 
 
-// API diff
-logger.metarpheusDiff('Diffing api files...');
-const {
-  output: apiOutput,
-  exitCode: apiExitCode
-} = diffLines(fs.readFileSync(metarpheusTcombConfig.apiOut, 'utf-8'), api)
-  .reduce(parseDiffs, parseDiffsAcc);
+    // model diff
+    logger.metarpheusDiff('Diffing models files...');
+    const {
+      output: modelOutput,
+      exitCode: modelExitCode
+    } = diffLines(fs.readFileSync(metarpheusTcombConfig.modelOut, 'utf-8'), model)
+        .reduce(parseDiffs, parseDiffsAcc);
 
-process.stdout.write(apiOutput);
+    process.stdout.write(modelOutput);
 
-
-// model diff
-logger.metarpheusDiff('Diffing models files...');
-const {
-  output: modelOutput,
-  exitCode: modelExitCode
-} = diffLines(fs.readFileSync(metarpheusTcombConfig.modelOut, 'utf-8'), model)
-    .reduce(parseDiffs, parseDiffsAcc);
-
-process.stdout.write(modelOutput);
-
-// exit with code from diffs
-process.exit(modelExitCode || apiExitCode);
+    // exit with code from diffs
+    process.exit(modelExitCode || apiExitCode);
+  })
+  .catch(logger.metarpheus);

--- a/src/scripts/metarpheus/download.js
+++ b/src/scripts/metarpheus/download.js
@@ -1,85 +1,99 @@
 import os from 'os';
 import request from 'request';
+import rp from 'request-promise';
 import fs from 'fs';
 import path from 'path';
+import progress from 'progress';
 import { logger } from '../../util';
 
 const homeDir = os.homedir();
 const metarpheusPath = path.resolve(homeDir, '.metarpheus');
+const metarpheusFileName = 'metarpheus.jar';
 
 const getLatestMetarpheusFileInfo = function() {
-  
-  logger.metarpheus(`Checking metarpheus.jar updates...`);
+
+  logger.metarpheus(`Checking for ${metarpheusFileName} updates...`);
 
   const options = {
     baseUrl: 'https://api.github.com',
     uri: '/repos/buildo/metarpheus/releases/latest',
     method: 'GET',
-    headers: {'user-agent': 'node.js'},
-    json: true
+    headers: { 'user-agent': 'node.js' },
+    json: true,
+    simple: true
   };
 
-  return new Promise((resolve, reject) => {
-    request(options, (err, res, body) => {
-      if(!err && res.statusCode === 200) {
-        const asset = body.assets.find(a => a.name === 'metarpheus.jar');
-        if (!asset) {
-          reject('metarpheus.jar not found');
-        }
-        else {
-          resolve({
-            url: asset.browser_download_url,
-            size: asset.size
-          });
-        }
-      } else {
-        reject(err || res.statusCode);
+  return rp(options)
+    .then(body => {
+      const asset = body.assets.find(a => a.name === metarpheusFileName);
+      if (!asset) {
+        return Promise.reject(`${metarpheusFileName} not found in latest release.`);
       }
-    })
-  });
+      return ({
+        url: asset.browser_download_url,
+        size: asset.size
+      });
+    });
 };
 
 const getLocalFileSize = function() {
   try {
-    return fs.statSync(metarpheusPath).size;
-  } catch(err) {
+    return fs.statSync(path.resolve(metarpheusPath, metarpheusFileName)).size;
+  } catch (err) {
     return 0;
   }
 };
 
 const downloadFile = function(url) {
-  if (!fs.existsSync(metarpheusPath)) {
-    fs.mkdirSync(metarpheusPath);
-  }
-  const file = fs.createWriteStream(path.resolve(metarpheusPath, 'metarpheus.jar'));
+  return new Promise((resolve, reject) => {
+    if (!fs.existsSync(metarpheusPath)) {
+      fs.mkdirSync(metarpheusPath);
+    }
+    const file = fs.createWriteStream(path.resolve(metarpheusPath, metarpheusFileName));
 
-  logger.metarpheus(`Downloading metarpheus jar from '${url}'`);
-  request
-    .get(url)
-    .on('response', response => {
-      if (response.statusCode === 404) {
-        throw new Error(`${METARPHEUS_URL} not found!`);
-      }
-    })
-    .on('error', (err) => logger.metarpheus(err))
-    .pipe(file);
+    logger.metarpheus(`Downloading metarpheus jar from '${url}'`);
 
-  file.on('close', () => {
-    logger.metarpheus(`File downloaded at: ${metarpheusPath}`);
+    request
+      .get(url)
+      .on('response', response => {
+        if (response.statusCode === 404) {
+          reject(`${url} not found!`);
+        } else {
+          const len = parseInt(response.headers['content-length'], 10);
+          const progressBar = new progress('  downloading [:bar] :percent eta: :etas', {
+            complete: '=',
+            incomplete: ' ',
+            width: 20,
+            total: len
+          });
+
+          response.on('data', chunk => {
+            progressBar.tick(chunk.length);
+          });
+
+          response.on('end', () => {
+            logger.metarpheus(`File downloaded at ${metarpheusPath}`);
+            resolve();
+          });
+        }
+      })
+      .on('error', (err) => {
+        reject(err);
+      })
+      .pipe(file);
   });
 };
 
 const downloadIfChanged = function(latestFileInfo) {
   const localFileSize = getLocalFileSize();
   if (!localFileSize || localFileSize !== latestFileInfo.size) {
-    downloadFile(latestFileInfo.url);
+    return downloadFile(latestFileInfo.url);
   } else {
-    logger.metarpheus('metarpheus.jar is up-to-date');
+    logger.metarpheus(`${metarpheusFileName} is up-to-date`);
   }
 };
 
 export default function download() {
-  getLatestMetarpheusFileInfo()
-    .then(downloadIfChanged)
-    .catch(logger.metarpheus);
+  return getLatestMetarpheusFileInfo()
+    .then(downloadIfChanged);
 }

--- a/src/scripts/metarpheus/index.js
+++ b/src/scripts/metarpheus/index.js
@@ -2,15 +2,20 @@ import fs from 'fs';
 import { logger } from '../../util';
 import runMetarpheusTcomb from './run';
 import metarpheusTcombConfig from './config';
+import download from './download';
 
-const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
+download()
+  .then(() => {
+    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
 
-// write api in api output file
-logger.metarpheus(`Writing ${metarpheusTcombConfig.apiOut}`);
-fs.writeFileSync(metarpheusTcombConfig.apiOut, api);
-logger.metarpheus('Finished!');
+    // write api in api output file
+    logger.metarpheus(`Writing ${metarpheusTcombConfig.apiOut}`);
+    fs.writeFileSync(metarpheusTcombConfig.apiOut, api);
+    logger.metarpheus('Finished!');
 
-// write model in model output file
-logger.metarpheus(`Writing ${metarpheusTcombConfig.modelOut}`);
-fs.writeFileSync(metarpheusTcombConfig.modelOut, model);
-logger.metarpheus('Finished!');
+    // write model in model output file
+    logger.metarpheus(`Writing ${metarpheusTcombConfig.modelOut}`);
+    fs.writeFileSync(metarpheusTcombConfig.modelOut, model);
+    logger.metarpheus('Finished!');
+  })
+  .catch(logger.metarpheus);


### PR DESCRIPTION
Issue #34

## Test Plan

### tests performed
- clone this branch
- `npm install` this branch => no download in postinstall
- `npm run metarpheus`/`npm run metarpheus-diff` will download `metarpheus.jar` before executing the task
- running a metarpheus task again will not download the jar again, since it's already found in `~/.metarpheus`