### PR TITLE
#9: metarpheus script fails if output path doesn't exist (closes #9)

### DIFF
--- a/src/scripts/metarpheus/index.js
+++ b/src/scripts/metarpheus/index.js
@@ -12,7 +12,8 @@ function mkDirs(filePath) {
         if (error.code === 'ENOENT') {
           return mkDirs(path.dirname(filePath))
             .then(() => mkDirs(filePath))
-            .then(resolve);
+            .then(resolve)
+            .catch(reject);
         }
         else {
           reject(error);
@@ -50,5 +51,6 @@ download()
         logger.metarpheus(`Writing ${metarpheusTcombConfig.modelOut}`);
         fs.writeFileSync(metarpheusTcombConfig.modelOut, model);
         logger.metarpheus('Finished!');
-      });
+      })
+      .catch(logger.metarpheus);
   });


### PR DESCRIPTION
Issue #9

## Test Plan

### tests performed
- clone this branch
- `npm install` local scriptoni in your project
- remove `metarpheus` dir
- run `npm run metarpheus`
  - it should create files inside `src/app/metarpheus` and not throwing for missing dir
