### PR TITLE
#38: Allow custom flags for metarpheus (closes #38)

### DIFF
--- a/src/scripts/metarpheus/index.js
+++ b/src/scripts/metarpheus/index.js
@@ -5,6 +5,8 @@ import runMetarpheusTcomb from './run';
 import metarpheusTcombConfig from './config';
 import download from './download';
 
+const args = process.argv.slice(2);
+
 function mkDirs(filePath) {
   return new Promise((resolve, reject) => {
     fs.mkdir(filePath, (error) => {
@@ -33,7 +35,7 @@ function mkDirsIfNotExist(filePath) {
 
 download()
   .then(() => {
-    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
+    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig, args);
 
     const apiOutDir = path.dirname(metarpheusTcombConfig.apiOut);
     const modelOutDir = path.dirname(metarpheusTcombConfig.modelOut);

--- a/src/scripts/metarpheus/run.js
+++ b/src/scripts/metarpheus/run.js
@@ -15,7 +15,7 @@ function buildCmdForExecuting(cmd) {
 const homeDir = os.homedir();
 
 // RUN METARPHEUS
-export default function runMetarpheusTcomb(metarpheusTcombConfig) {
+export default function runMetarpheusTcomb(metarpheusTcombConfig, args) {
 
   const cwd = process.cwd();
 
@@ -36,6 +36,7 @@ export default function runMetarpheusTcomb(metarpheusTcombConfig) {
     `-jar ${metarpheusJar}`,
     `--config=${cfg}`,
     `--output=${otp}`,
+    ...args,
     `${apiPath}`
   ];
 


### PR DESCRIPTION
Issue #38

## Test Plan

### tests performed
- clone branch locally
- `npm i` local scriptoni
- add `--wiro` to metarpheus command (`scriptoni metarpheus --wiro`) in `package.json`
- run `npm run metarpheus`