### PR TITLE
#46: Add flag to metarpheus-diff  (closes #46)

### DIFF
--- a/src/scripts/metarpheus-diff/index.js
+++ b/src/scripts/metarpheus-diff/index.js
@@ -6,10 +6,12 @@ import runMetarpheusTcomb from '../metarpheus/run';
 import { logger } from '../../util';
 import download from '../metarpheus/download';
 
+const args = process.argv.slice(2);
+
 download()
   .then(() => {
 
-    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig);
+    const { model, api } = runMetarpheusTcomb(metarpheusTcombConfig, args);
 
     const parseDiffsAcc = {
       output: '\n',


### PR DESCRIPTION
Issue #46

## Test Plan

### tests performed
`node bin/scriptoni metarpheus-diff` ✔️ 

```sh
$ npm run metarpheus-diff

> operational-dashboard@0.0.17 metarpheus-diff /Users/andreaascari/Workspace/buildo/abbott/qia/qia/web
> scriptoni metarpheus-diff

  scripto:metarpheus Checking for metarpheus.jar updates... +0ms
  scripto:metarpheus metarpheus.jar is up-to-date +1s
  scripto:metarpheus Using scala config: /Users/andreaascari/Workspace/buildo/abbott/qia/qia/web/metarpheus-config.scala +1ms
  scripto:metarpheus Starting
  scripto:metarpheus
  scripto:metarpheus  java
  scripto:metarpheus  -jar /Users/andreaascari/.metarpheus/metarpheus.jar
  scripto:metarpheus  --config=/Users/andreaascari/Workspace/buildo/abbott/qia/qia/web/metarpheus-config.scala
  scripto:metarpheus  --output=/Users/andreaascari/Workspace/buildo/abbott/qia/qia/web/node_modules/scriptoni/lib/scripts/metarpheus/metarpheus-interm-rep.json
  scripto:metarpheus  /Users/andreaascari/Workspace/buildo/abbott/qia/qia/backend/operationalDashboardWebApi /Users/andreaascari/Workspace/buildo/abbott/qia/qia/backend/operationalDashboardShared
  scripto:metarpheus
  scripto:metarpheus   +2ms
  scripto:metarpheus Finished
  scripto:metarpheus
  scripto:metarpheus  java
  scripto:metarpheus  -jar /Users/andreaascari/.metarpheus/metarpheus.jar
  scripto:metarpheus  --config=/Users/andreaascari/Workspace/buildo/abbott/qia/qia/web/metarpheus-config.scala
  scripto:metarpheus  --output=/Users/andreaascari/Workspace/buildo/abbott/qia/qia/web/node_modules/scriptoni/lib/scripts/metarpheus/metarpheus-interm-rep.json
  scripto:metarpheus  /Users/andreaascari/Workspace/buildo/abbott/qia/qia/backend/operationalDashboardWebApi /Users/andreaascari/Workspace/buildo/abbott/qia/qia/backend/operationalDashboardShared
  scripto:metarpheus
  scripto:metarpheus   +12s
  scripto:metarpheus Starting metarpheus-tcomb +0ms
  scripto:metarpheus Finished metarpheus-tcomb +95ms
  scripto:metarpheus-diff Diffing api files... +0ms

  scripto:metarpheus-diff Diffing models files... +10ms
```

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
