### PR TITLE
#52: scriptoni lint doesn't exit with eslint exit status (closes #52)

### DIFF
--- a/src/scripts/eslint/index.js
+++ b/src/scripts/eslint/index.js
@@ -7,3 +7,7 @@ const formatter = cli.getFormatter('stylish');
 
 const report = cli.executeOnFiles(['src']);
 console.log(formatter(report.results));     // eslint-disable-line no-console
+
+if (report.errorCount > 0) {
+  process.exit(1);
+}

--- a/src/scripts/metarpheus-diff/index.js
+++ b/src/scripts/metarpheus-diff/index.js
@@ -64,4 +64,7 @@ download()
     // exit with code from diffs
     process.exit(modelExitCode || apiExitCode);
   })
-  .catch(logger.metarpheus);
+  .catch(e => {
+    logger.metarpheus(e);
+    process.exit(1);
+  });

--- a/src/scripts/metarpheus/index.js
+++ b/src/scripts/metarpheus/index.js
@@ -54,5 +54,8 @@ download()
         fs.writeFileSync(metarpheusTcombConfig.modelOut, model);
         logger.metarpheus('Finished!');
       })
-      .catch(logger.metarpheus);
+      .catch(e => {
+        logger.metarpheus(e);
+        process.exit(1);
+      });
   });

--- a/src/scripts/stylelint/index.js
+++ b/src/scripts/stylelint/index.js
@@ -31,5 +31,13 @@ const options = {
 };
 
 lint(options)
-  .then(({ output }) => console.log(output)) // eslint-disable-line no-console
-  .catch((err) => console.log(red(err.stack))); // eslint-disable-line no-console
+  .then(({ output, errored }) => {
+    console.log(output); // eslint-disable-line no-console
+    if (errored) {
+      process.exit(1);
+    }
+  })
+  .catch((err) => {
+    console.log(red(err.stack)); // eslint-disable-line no-console
+    process.exit(1);
+  });


### PR DESCRIPTION
Issue #52

## Test Plan

### tests performed
`npm run lint`, `npm run lint-style` and `npm run metarpheus-diff` exit with status = 1 on failure
