### PR TITLE
#65: stylefmt default params are wrong (closes #65)

### DIFF
--- a/src/scripts/stylelint/stylefmt.js
+++ b/src/scripts/stylelint/stylefmt.js
@@ -6,8 +6,7 @@ const cwd = process.cwd();
 const cmd = path.resolve(cwd, 'node_modules', 'stylefmt', 'bin', 'cli.js');
 
 const defaultArgs = {
-  recursive: true,
-  _: ['src/**/*.scss']
+  recursive: 'src/**/*.scss'
 };
 
 execCommand(cmd, defaultArgs, logger.lintStyle);


### PR DESCRIPTION
Closes #65

## Test Plan

### tests performed
Tested on GDSM. `npm run lint-style-fix` is working