### PR TITLE
#67: Add --bail to webpack configuration (closes #67)

### DIFF
--- a/src/scripts/webpack/webpack.build.js
+++ b/src/scripts/webpack/webpack.build.js
@@ -32,6 +32,8 @@ export default ({ config, paths, NODE_ENV }) => {
   return {
     ...base,
 
+    bail: true,
+
     entry: path.resolve(paths.SRC, 'client/index.js'),
 
     devtool: 'source-map',


### PR DESCRIPTION
Closes #67

## Test Plan

### tests performed

- with no `bail`
```
$npm run build

> operational-dashboard@0.0.17 build /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> npm run clean && UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config


> operational-dashboard@0.0.17 clean /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> npm run clean-react && rm -rf build/* && mkdir -p build


> operational-dashboard@0.0.17 clean-react /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> rm -rf node_modules/react-intl/node_modules/react || true

  scriptoni:webpack building with NODE_ENV=development +0ms
  scriptoni:webpack Configuration {
    "port": 8080,
    "(bundled) apiEndpoint": "https://corsproxy.our.buildo.io/http://alinity-pro-dev.omnilab-development.com:8005/v1",
    "devTool": "source-map",
    "title": "Alinity PRO",
    "(bundled) username": "claudio",
    "(bundled) password": "claudio",
    "(bundled) debug": "app*,*API*,state*"
} +2ms
  scriptoni:webpack Start compiling... +1s
Build completed in 11.531s

  scriptoni:webpack Hash: 3ceaa79b9ecd95c8c191
  scriptoni:webpack Version: webpack 1.15.0
  scriptoni:webpack Time: 12866ms
  scriptoni:webpack
  scriptoni:webpack ERROR in ./src/app/routes/index.js
  scriptoni:webpack Module build failed: Module failed because of a eslint error.
  scriptoni:webpack
  scriptoni:webpack /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web/src/app/routes/index.js
  scriptoni:webpack   9:40  error  'App' is not defined  no-undef
  scriptoni:webpack
  scriptoni:webpack ✖ 1 problem (1 error, 0 warnings)
  scriptoni:webpack
  scriptoni:webpack  @ ./src/client/index.js 24:13-30 +12s
```


- with `bail: true`

```
$npm run build

> operational-dashboard@0.0.17 build /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> npm run clean && UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config


> operational-dashboard@0.0.17 clean /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> npm run clean-react && rm -rf build/* && mkdir -p build


> operational-dashboard@0.0.17 clean-react /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web
> rm -rf node_modules/react-intl/node_modules/react || true

  scriptoni:webpack building with NODE_ENV=development +0ms
  scriptoni:webpack Configuration {
    "port": 8080,
    "(bundled) apiEndpoint": "https://corsproxy.our.buildo.io/http://alinity-pro-dev.omnilab-development.com:8005/v1",
    "devTool": "source-map",
    "title": "Alinity PRO",
    "(bundled) username": "claudio",
    "(bundled) password": "claudio",
    "(bundled) debug": "app*,*API*,state*"
} +2ms
  scriptoni:webpack Start compiling... +1s
  build [=====               ] 25%
/Users/andreaascari/Workspace/buildo/scriptoni/lib/scripts/webpack/build.js:19
    throw err;
    ^
ModuleBuildError: Module build failed: Module failed because of a eslint error.

/Users/andreaascari/Workspace/abbott/alinity-pro/qia/web/src/app/routes/index.js
  9:40  error  'App' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)

    at DependenciesBlock.onModuleBuildFailed (/Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:315:19)
    at nextLoader (/Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:270:31)
    at /Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:292:15
    at runSyncOrAsync (/Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:173:4)
    at nextLoader (/Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:290:3)
    at /Users/andreaascari/Workspace/buildo/scriptoni/node_modules/webpack-core/lib/NormalModuleMixin.js:259:5
    at Storage.finished (/Users/andreaascari/Workspace/buildo/scriptoni/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:16)
    at /Users/andreaascari/Workspace/buildo/scriptoni/node_modules/graceful-fs/graceful-fs.js:78:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:445:3)

npm ERR! Darwin 16.5.0
npm ERR! argv "/Users/andreaascari/.nvm/versions/node/v6.9.2/bin/node" "/Users/andreaascari/.nvm/versions/node/v6.9.2/bin/npm" "run" "build"
npm ERR! node v6.9.2
npm ERR! npm  v4.1.2
npm ERR! code ELIFECYCLE
npm ERR! operational-dashboard@0.0.17 build: `npm run clean && UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the operational-dashboard@0.0.17 build script 'npm run clean && UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the operational-dashboard package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     npm run clean && UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs operational-dashboard
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls operational-dashboard
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/andreaascari/Workspace/abbott/alinity-pro/qia/web/npm-debug.log
```

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
