### PR TITLE
#71: Enable HMR for webpack dev task (closes #71)

### DIFF
--- a/src/scripts/webpack/dev.js
+++ b/src/scripts/webpack/dev.js
@@ -3,13 +3,16 @@ import webpackServer from 'webpack-dev-server';
 import webpackConfig from './webpack.config.js';
 import compiler from './compiler';
 import getConfig from './config';
+import getPaths from './paths';
 import { statsOutputConfiguration } from './util';
 
 const args = minimist(process.argv.slice(2));
+const paths = getPaths(args);
 
 const server = new webpackServer(compiler(webpackConfig), {
-  stats: statsOutputConfiguration,
-  hot: true
+  contentBase: paths.BUILD,
+  hot: true,
+  stats: statsOutputConfiguration
 });
 
 server.listen(getConfig(args).port);

--- a/src/scripts/webpack/webpack.config.js
+++ b/src/scripts/webpack/webpack.config.js
@@ -10,19 +10,12 @@ export default ({ config, paths, NODE_ENV }) => {
   return {
     ...base,
     entry: [
+      `webpack-dev-server/client?http://0.0.0.0:${config.port}/`,
       'webpack/hot/dev-server',
       path.resolve(paths.SRC, 'client/index.js')
     ],
 
     devtool: config.devTool || 'source-map',
-
-    devServer: {
-      contentBase: paths.BUILD,
-      hot: true,
-      inline: true,
-      port: config.port,
-      host: '0.0.0.0'
-    },
 
     plugins: [
       ...base.plugins,


### PR DESCRIPTION
Closes #71

## Test Plan

### tests performed
- changes on code trigger browser refresh (for both `localhost:$PORT` and `$LOCAL_IP:$PORT`)✅ 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
