### PR TITLE
#78: [webpack] env configs not already contained in file config are not considered (closes #78)

### DIFF
--- a/src/scripts/webpack/config.js
+++ b/src/scripts/webpack/config.js
@@ -49,13 +49,13 @@ const getConfigType = (configFolderPath) => {
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 
-const getConfigurationFromEnv = (config = {}) => {
-  return Object.keys(config).reduce((acc, k) => {
+const getConfigurationFromEnv = (keys) => {
+  return keys.reduce((acc, k) => {
     const envVar = process.env[jsConfigVariableToEnvConfigVariable(k)];
-    return {
-      ...acc,
-      [k]: envVar || config[k]
-    };
+    if (typeof envVar !== 'undefined') {
+      acc[k] = envVar;
+    }
+    return acc;
   }, {});
 };
 
@@ -85,9 +85,15 @@ export default function getConfig(args) {
   const ConfigType = getConfigType(configFolderPath);
 
   // merge environment config values into fileConfig
+  const topLevelKeys = Object.keys(omit(ConfigType.meta.props, 'bundle'));
+  const bundleKeys = Object.keys(ConfigType.meta.props.bundle.meta.props);
   const config = {
-    ...getConfigurationFromEnv(omit(fileConfig, 'bundle')),
-    bundle: getConfigurationFromEnv(fileConfig.bundle)
+    ...fileConfig,
+    ...getConfigurationFromEnv(topLevelKeys),
+    bundle: {
+      ...fileConfig.bundle,
+      ...getConfigurationFromEnv(bundleKeys)
+    }
   };
 
   if (!ConfigType.is(config)) {


### PR DESCRIPTION
Closes #78

## Test Plan

### tests performed

- verified the example from the issue now works correctly
- tested locally on aliniq `production`

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
