### PR TITLE
#86: cleanup webpack config handling (closes #86)

### DIFF
--- a/src/scripts/webpack/config.js
+++ b/src/scripts/webpack/config.js
@@ -52,11 +52,9 @@ const getConfigType = (configFolderPath) => {
     return require(configTypePath);
   } catch (e) {
     /* eslint-disable no-console */
-    console.warn(`
-      Error while importing Config type definition file ${configTypePath}, using the default one...
-    `);
+    console.error(`Invalid Config type definition file: ${configTypePath}`);
     /* eslint-enable no-console */
-    return defaultConfigType;
+    process.exit(1);
   }
 };
 

--- a/src/scripts/webpack/config.js
+++ b/src/scripts/webpack/config.js
@@ -34,13 +34,21 @@ const readOptionalConfigFile = fullPath => {
 
 // try to load configuration type from the user project, fallback on BaseConfig
 const getConfigType = (configFolderPath) => {
-  const configTypePath = path.resolve(configFolderPath, './Config');
+  const configTypePath = path.resolve(configFolderPath, './Config.js');
   try {
+    if (!fs.existsSync(configTypePath)) {
+      /* eslint-disable no-console */
+      console.warn(`
+        No Config type definition file found in ${configTypePath}, using the default one...
+      `);
+      /* eslint-enable no-console */
+      return t.Any;
+    }
     return require(configTypePath);
   } catch (e) {
     /* eslint-disable no-console */
     console.warn(`
-      No Config type definition file found in ${configTypePath}, using the default one...
+      Error while importing Config type definition file ${configTypePath}, using the default one...
     `);
     /* eslint-enable no-console */
     return t.Any;

--- a/src/scripts/webpack/config.js
+++ b/src/scripts/webpack/config.js
@@ -3,6 +3,11 @@ import path from 'path';
 import t from 'tcomb';
 import omit from 'lodash/omit';
 
+const defaultConfigType = t.interface({
+  bundle: t.interface({
+  })
+}, { name: 'Config', strict: true });
+
 // Get path for user configuration, default to './config' from user current working directory
 const getConfigRelativePath = (args) => {
   const configRelativePath = args.c || './config';
@@ -42,7 +47,7 @@ const getConfigType = (configFolderPath) => {
         No Config type definition file found in ${configTypePath}, using the default one...
       `);
       /* eslint-enable no-console */
-      return t.Any;
+      return defaultConfigType;
     }
     return require(configTypePath);
   } catch (e) {
@@ -51,7 +56,7 @@ const getConfigType = (configFolderPath) => {
       Error while importing Config type definition file ${configTypePath}, using the default one...
     `);
     /* eslint-enable no-console */
-    return t.Any;
+    return defaultConfigType;
   }
 };
 

--- a/src/scripts/webpack/config.js
+++ b/src/scripts/webpack/config.js
@@ -40,22 +40,15 @@ const readOptionalConfigFile = fullPath => {
 // try to load configuration type from the user project, fallback on BaseConfig
 const getConfigType = (configFolderPath) => {
   const configTypePath = path.resolve(configFolderPath, './Config.js');
-  try {
-    if (!fs.existsSync(configTypePath)) {
-      /* eslint-disable no-console */
-      console.warn(`
+  if (!fs.existsSync(configTypePath)) {
+    /* eslint-disable no-console */
+    console.warn(`
         No Config type definition file found in ${configTypePath}, using the default one...
       `);
-      /* eslint-enable no-console */
-      return defaultConfigType;
-    }
-    return require(configTypePath);
-  } catch (e) {
-    /* eslint-disable no-console */
-    console.error(`Invalid Config type definition file: ${configTypePath}`);
     /* eslint-enable no-console */
-    process.exit(1);
+    return defaultConfigType;
   }
+  return require(configTypePath);
 };
 
 const nodeEnv = process.env.NODE_ENV || 'development';


### PR DESCRIPTION
Closes #86

## Test Plan

### tests performed
* tested on a local project that the errors are different when `config/Config.js` does not exist and is broken.
* tested also that the default config works by removing the config folder and running `npm start`

### tests not performed (domain coverage)
