### PR TITLE
#87: webpack: dev-server is not listening on 0.0.0.0 (closes #87)

### DIFF
--- a/src/scripts/webpack/dev.js
+++ b/src/scripts/webpack/dev.js
@@ -12,7 +12,8 @@ const paths = getPaths(args);
 const server = new webpackServer(compiler(webpackConfig), {
   contentBase: paths.BUILD,
   hot: true,
-  stats: statsOutputConfiguration
+  stats: statsOutputConfiguration,
+  disableHostCheck: true
 });
 
 server.listen(getConfig(args).port);


### PR DESCRIPTION
Closes #87

Added `disableHostCheck: true` as a parameter to the `webpackServer`, as suggested here:
https://github.com/webpack/webpack-dev-server/issues/882

## Test Plan

### tests performed
Run `npm start` and checked that connecting through `0.0.0.0:8080` and through my local IP works.

### tests not performed (domain coverage)
