### PR TITLE
webpack ts+babel

### DIFF
--- a/src/scripts/webpack/tsconfig.json
+++ b/src/scripts/webpack/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "ESNext",
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,

--- a/src/scripts/webpack/webpack.base.js
+++ b/src/scripts/webpack/webpack.base.js
@@ -78,7 +78,13 @@ export default ({ config, paths, NODE_ENV, jsLoader = JSLoader('babel') }) => {
           // TypeScript transpiler
           return {
             test: /\.tsx?$|\.jsx?$/,
-            use: [{ loader: 'awesome-typescript-loader' }],
+            use: [{
+              loader: 'awesome-typescript-loader',
+              options: {
+                useBabel: true,
+                useCache: true
+              }
+            }],
             exclude: [paths.ASSETS],
             include: [paths.SRC]
           };


### PR DESCRIPTION
Instead of using TS for producing the final es5 JS, pass through babel as final step.

This could save us from a few possible headaches (https://github.com/Microsoft/TypeScript/issues/16096) and/or differences in final bundle, ~~at the expense of some of the performance improvements TS would introduce~~ *EDIT*: turns out this is not true, at least not considering:
- aliniq
- awesome-typescript-loader caching
- TS with target "ESNext"

**summary of times on my machine**
average of 10 runs, each run is a `NODE_ENV=production npm run build`
- times excluding uglify+gzip were taken removing that part from webpack config completely)
- re-build times were taken editing `PopoverContainer.js` and writing down the "Build completed in X" log, again averaged on 10 runs

| project | setup | time in seconds | time including uglify+gzip | re-build time | comments
| --- | ---- | ---- | ---- | --- | --- |
| aliniq | webpack@1, babel (current) | 42.5 | 73.7 | 5.7 | |
| aliniq | webpack@2, babel | 80 | 107.8 | 9 | |
| aliniq | webpack@1, TS | 30 | 57.2 | 7.3 | PR on aliniq https://github.omnilab.our.buildo.io/buildo/aliniq/pull/5590 |
| **aliniq** | **webpack@2, babel+TS** | **68.6** | **92.7** | **7.2** | **(this PR)** |
| **aliniq** | **webpack@2, babel+TS (no cache)** | **101.2** | **113.6** | | **(this PR) This is a build from scratch, without previous `.awcache`, basically as it'd perform on CI** |
| aliniq | webpack@2, TS | 71.6 | 98.1 | | |
| webseed | webpack@2, babel | 7.5 | 14 | 1.1 | |
| gdsm/web | webpack@1, babel (current) | ~27 | | | by vince |
| gdsm/web | webpack@2, babel | ~34 | | | by vince |
| gdsm/backoffice | webpack@1, babel (current) | ~17 | | | by vince |
| gdsm/backoffice | webpack@2, babel | ~23 | | | by vince |
| bobafett | webpack@1, babel (current) | 15.9 | 37 | | |
| bobafett | webpack@2, babel | 25.5 | 50 | 3.4 | |