### PR TITLE
#106: add metarpheus-ts scripts (closes #106)

### DIFF
--- a/bin/scriptoni.js
+++ b/bin/scriptoni.js
@@ -4,8 +4,8 @@ var spawn = require('cross-spawn');
 var script = process.argv[2];
 var args = process.argv.slice(3);
 
-function spawnScript(script) {
-  const cmd = [require.resolve('../lib/scripts/' + script)].concat(args);
+function spawnScript(script, moreArgs = []) {
+  const cmd = [require.resolve('../lib/scripts/' + script)].concat(args).concat(moreArgs);
   return spawn.sync('node', cmd, { stdio: 'inherit' });
 }
 
@@ -17,6 +17,9 @@ switch (script) {
   case 'metarpheus':
   case 'metarpheus-diff':
     exit(spawnScript(script));
+    break;
+  case 'metarpheus-ts':
+    exit(spawnScript('metarpheus', ['--ts']));
     break;
   case 'lint-style':
     exit(spawnScript('stylelint'));

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
     "html-webpack-plugin": "^2.28.0",
+    "io-ts": "^0.5.0",
+    "metarpheus-io-ts": "^0.1.2",
     "metarpheus-tcomb": "^0.2",
     "minimist": "^1.2.0",
     "node-glob": "^1.2.0",

--- a/src/scripts/metarpheus/config.js
+++ b/src/scripts/metarpheus/config.js
@@ -1,29 +1,44 @@
 import fs from 'fs';
 import path from 'path';
 
-// get current working directory
-const cwd = process.cwd();
-// define user javascript config file path
-const ujcFilePath = path.resolve(cwd, 'metarpheus-config.js');
+export default function(ts) {
+  // get current working directory
+  const cwd = process.cwd();
+  // define user javascript config file path
+  const ujcFilePath = path.resolve(cwd, ts ? 'metarpheus-ts-config.js' : 'metarpheus-config.js');
 
-// TODO: fs.existsSync is deprecated
-const ujc = fs.existsSync(ujcFilePath) && require(ujcFilePath) || {};
+  // TODO: fs.existsSync is deprecated
+  const ujc = fs.existsSync(ujcFilePath) && require(ujcFilePath) || {};
 
-// default module prelude
-const modelPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
-/* eslint-disable */
-import t from 'tcomb';
-`;
+  if (ts) {
+    return {
+      isReadonly: false,
+      runtime: false,
+      newtypes: [],
+      apiPath: path.resolve(cwd, '../api/src/main/scala'),
+      modelOut: path.resolve(cwd, 'src/app/metarpheus/model.ts'),
+      apiOut: path.resolve(cwd, 'src/app/metarpheus/api.ts'),
+      intermRepIn: path.resolve(__dirname, 'metarpheus-interm-rep.json'),
+      ...ujc
+    };
+  } else {
+    // default module prelude
+    const modelPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
+    /* eslint-disable */
+    import t from 'tcomb';
+    `;
 
-export default {
-  apiPath: path.resolve(cwd, '../api/src/main/scala'),
-  modelPrelude,
-  apiPrelude: `${modelPrelude}
-import * as m from './model';
-`,
-  apiModelPrefix: 'm.',
-  modelOut: path.resolve(cwd, 'src/app/metarpheus/model.js'),
-  apiOut: path.resolve(cwd, 'src/app/metarpheus/api.js'),
-  intermRepIn: path.resolve(__dirname, 'metarpheus-interm-rep.json'),
-  ...ujc
-};
+    return {
+      apiPath: path.resolve(cwd, '../api/src/main/scala'),
+      modelPrelude,
+      apiPrelude: `${modelPrelude}
+    import * as m from './model';
+    `,
+      apiModelPrefix: 'm.',
+      modelOut: path.resolve(cwd, 'src/app/metarpheus/model.js'),
+      apiOut: path.resolve(cwd, 'src/app/metarpheus/api.js'),
+      intermRepIn: path.resolve(__dirname, 'metarpheus-interm-rep.json'),
+      ...ujc
+    };
+  }
+}

--- a/src/scripts/metarpheus/index.js
+++ b/src/scripts/metarpheus/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { logger } from '../../util';
 import { runMetarpheusTcomb, runMetarpheusIoTs } from './run';
-import getMetarpheusJSConfig from './config';
+import getMetarpheusConfig from './config';
 import download from './download';
 
 const _args = process.argv.slice(2);
@@ -35,15 +35,15 @@ function mkDirsIfNotExist(filePath) {
   return Promise.resolve();
 }
 
-const metarpheusJSConfig = getMetarpheusJSConfig(ts);
+const metarpheusConfig = getMetarpheusConfig(ts);
 
 download()
   .then(() => {
-    const apiOutDir = path.dirname(metarpheusJSConfig.apiOut);
-    const modelOutDir = path.dirname(metarpheusJSConfig.modelOut);
+    const apiOutDir = path.dirname(metarpheusConfig.apiOut);
+    const modelOutDir = path.dirname(metarpheusConfig.modelOut);
 
     const { model, api } = (() =>
-      (ts ? runMetarpheusIoTs : runMetarpheusTcomb)(metarpheusJSConfig, args)
+      (ts ? runMetarpheusIoTs : runMetarpheusTcomb)(metarpheusConfig, args)
     )();
 
     // create dirs if don't exist
@@ -51,13 +51,13 @@ download()
       .then(() => mkDirsIfNotExist(modelOutDir))
       .then(() => {
         // write api in api output file
-        logger.metarpheus(`Writing ${metarpheusJSConfig.apiOut}`);
-        fs.writeFileSync(metarpheusJSConfig.apiOut, api);
+        logger.metarpheus(`Writing ${metarpheusConfig.apiOut}`);
+        fs.writeFileSync(metarpheusConfig.apiOut, api);
         logger.metarpheus('Finished!');
 
         // write model in model output file
-        logger.metarpheus(`Writing ${metarpheusJSConfig.modelOut}`);
-        fs.writeFileSync(metarpheusJSConfig.modelOut, model);
+        logger.metarpheus(`Writing ${metarpheusConfig.modelOut}`);
+        fs.writeFileSync(metarpheusConfig.modelOut, model);
         logger.metarpheus('Finished!');
       })
       .catch(e => {

--- a/src/scripts/metarpheus/run.js
+++ b/src/scripts/metarpheus/run.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import metarpheusTcomb from 'metarpheus-tcomb';
+import { getModels, getRoutes } from 'metarpheus-io-ts';
 import { logger } from '../../util';
 function buildCmdForLogging(cmd) {
   return [' \n '].concat(cmd).join(' \n ').concat([' \n \n ']);
@@ -14,9 +15,7 @@ function buildCmdForExecuting(cmd) {
 
 const homeDir = os.homedir();
 
-// RUN METARPHEUS
-export default function runMetarpheusTcomb(metarpheusTcombConfig, args) {
-
+function runMetarpheus(metarpheusTcombConfig, args) {
   const cwd = process.cwd();
 
   // define user scala configuration (usc) file path
@@ -44,7 +43,12 @@ export default function runMetarpheusTcomb(metarpheusTcombConfig, args) {
   logger.metarpheus(`Starting ${buildCmdForLogging(metarpheusCmd)}`);
   execSync(buildCmdForExecuting(metarpheusCmd));
   logger.metarpheus(`Finished ${buildCmdForLogging(metarpheusCmd)}`);
+}
 
+// RUN METARPHEUS
+export function runMetarpheusTcomb(metarpheusTcombConfig, args) {
+
+  runMetarpheus(metarpheusTcombConfig, args);
 
   // METARPHEUS-TCOMB
   logger.metarpheus('Starting metarpheus-tcomb');
@@ -69,4 +73,22 @@ export default function runMetarpheusTcomb(metarpheusTcombConfig, args) {
   });
   logger.metarpheus('Finished metarpheus-tcomb');
   return { model, api };
+}
+
+export function runMetarpheusIoTs(metarpheusTsConfig, args) {
+
+  runMetarpheus(metarpheusTsConfig, args);
+
+  logger.metarpheus('Starting metarpheus-io-ts');
+  const { intermRepIn } = metarpheusTsConfig;
+  const source = require(intermRepIn);
+  // TODO(gio): "prelude" should eventually be supported by metarhpeus-io-ts directly
+  const model = `
+${metarpheusTsConfig.modelPrelude}
+
+${getModels(source.models, metarpheusTsConfig)}
+`;
+  logger.metarpheus('Finished metarpheus-io-ts');
+  // TODO(gio): we are not currently interested in `api`
+  return { model, api: '' };
 }


### PR DESCRIPTION
Closes #106

## Test Plan

### tests performed

- tested on https://github.omnilab.our.buildo.io/buildo/aliniq/pull/5668 (see the generated model.ts there -- seems 👍 )
- tested that the "normal" metarpheus script still works 👍 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
