### PR TITLE
Improve diff of metarpheus-diff

### DIFF
--- a/src/scripts/metarpheus-diff/index.js
+++ b/src/scripts/metarpheus-diff/index.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { diffLines } from 'diff';
+import { structuredPatch, createTwoFilesPatch } from 'diff';
 import { green, red } from 'chalk';
 import getMetarpheusConfig from '../metarpheus/config';
 import { runMetarpheusTcomb, runMetarpheusIoTs } from '../metarpheus/run';
@@ -17,53 +17,37 @@ download()
 
     const { model, api } = (ts ? runMetarpheusIoTs : runMetarpheusTcomb)(metarpheusConfig, args);
 
-    const parseDiffsAcc = {
-      output: '\n',
-      exitCode: 0
-    };
-
-    function getExitCode(part, exitCode) {
-      if (part.added || part.removed) {
-        return 1;
+    function colorLine(line) {
+      switch (line[0]) {
+        case '+': return green(line);
+        case '-': return red(line);
+        default: return line;
       }
-      return exitCode;
     }
 
-    function buildOutput(part) {
-      if (part.added || part.removed) {
-        const color = part.added ? green : red;
-        return color(part.value);
-      }
-      return '';
-    }
-
-    function parseDiffs({ output, exitCode }, part) {
-      return {
-        exitCode: getExitCode(part, exitCode),
-        output: output + buildOutput(part)
-      };
+    function colorizePatch(patch) {
+      return patch.split('\n').map(colorLine).join('\n');
     }
 
     // API diff
     logger.metarpheusDiff('Diffing api files...');
-    const {
-      output: apiOutput,
-      exitCode: apiExitCode
-    } = diffLines(fs.readFileSync(metarpheusConfig.apiOut, 'utf-8'), api)
-      .reduce(parseDiffs, parseDiffsAcc);
+    const apiNew = fs.readFileSync(metarpheusConfig.apiOut, 'utf-8');
+    const apiExitCode = structuredPatch('', '', api, apiNew).hunks.length === 0 ? 0 : 1;
+    const apiOutput = colorizePatch(createTwoFilesPatch('current', 'new', api, apiNew));
 
-    process.stdout.write(apiOutput);
-
+    if (apiExitCode !== 0) {
+      process.stdout.write(apiOutput);
+    }
 
     // model diff
     logger.metarpheusDiff('Diffing models files...');
-    const {
-      output: modelOutput,
-      exitCode: modelExitCode
-    } = diffLines(fs.readFileSync(metarpheusConfig.modelOut, 'utf-8'), model)
-        .reduce(parseDiffs, parseDiffsAcc);
+    const modelNew = fs.readFileSync(metarpheusConfig.modelOut, 'utf-8');
+    const modelExitCode = structuredPatch('', '', model, modelNew).hunks.length === 0 ? 0 : 1;
+    const modelOutput = colorizePatch(createTwoFilesPatch('current', 'new', model, modelNew));
 
-    process.stdout.write(modelOutput);
+    if (modelExitCode !== 0) {
+      process.stdout.write(modelOutput);
+    }
 
     // exit with code from diffs
     process.exit(modelExitCode || apiExitCode);

--- a/src/scripts/metarpheus-diff/index.js
+++ b/src/scripts/metarpheus-diff/index.js
@@ -36,7 +36,7 @@ download()
     const apiOutput = colorizePatch(createTwoFilesPatch('current', 'new', api, apiNew));
 
     if (apiExitCode !== 0) {
-      process.stdout.write(apiOutput);
+      console.log(apiOutput); // eslint-disable-line no-console
     }
 
     // model diff
@@ -46,7 +46,7 @@ download()
     const modelOutput = colorizePatch(createTwoFilesPatch('current', 'new', model, modelNew));
 
     if (modelExitCode !== 0) {
-      process.stdout.write(modelOutput);
+      console.log(modelOutput); // eslint-disable-line no-console
     }
 
     // exit with code from diffs


### PR DESCRIPTION
Currently the diff is custom-made and only color-based.

Also, since we're using `process.stdout.write` the colors are not rendered.

This causes the output on the CI to be close to useless:

![image](https://user-images.githubusercontent.com/691940/28125312-8a49ba3c-6726-11e7-8c7a-c2799b082ec9.png)


This PR takes a different approach and it uses the `createTwoFilesPatch` two produce a standard diff, then colored based on the first character of each line:

![image](https://user-images.githubusercontent.com/691940/28125525-1da3824a-6727-11e7-86a4-3b9d17c8f880.png)
