### PR TITLE
Fix TS 2.5.0 complains about ESNext not being a valid target

### DIFF
--- a/src/scripts/webpack/tsconfig.json
+++ b/src/scripts/webpack/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ESNext",
+    "target": "esnext",
     "noImplicitAny": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
`esnext` instead of `ESNext` seems to fix it.