### PR TITLE
Update webpack-fail-plugin to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "virtual-module-webpack-plugin": "^0.3.0",
     "webpack": "^3.1.0",
     "webpack-dev-server": "^2.5.1",
-    "webpack-fail-plugin": "^1.0.6"
+    "webpack-fail-plugin": "^2.0.0"
   }
 }


### PR DESCRIPTION
2.0.0 simply allows webpack 2 and 3 as peerDep, removing a warning during npm install.

See https://github.com/TiddoLangerak/webpack-fail-plugin/pull/14