### PR TITLE
#167: Updating metarpheus-io-ts (closes #167)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "html-webpack-plugin": "^2.29.0",
     "io-ts": "^0.9.2",
     "metarpheus": "0.1.7",
-    "metarpheus-io-ts": "^0.1.12",
+    "metarpheus-io-ts": "^0.1.14",
     "metarpheus-tcomb": "^0.2",
     "minimist": "^1.2.0",
     "node-glob": "^1.2.0",


### PR DESCRIPTION
Closes #167

## Test Plan

### tests performed

* Build passes.
* Tested locally on a project that uses `scriptoni`: `metarpheus-io-ts` version is now correct in the yarn lock:

![image](https://user-images.githubusercontent.com/6418684/36196754-fed32a78-1171-11e8-8fd4-eecbd4641a97.png)
