### PR TITLE
#170: Build breaks if you remove ie11 from browsers (.babelrc) (closes #170)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "svg-react-loader": "^0.4.4",
     "ts-loader": "^3.2.0",
     "typescript": "^2.6.2",
+    "uglifyjs-webpack-plugin": "^1.2.3",
     "virtual-module-webpack-plugin": "^0.3.0",
     "webpack": "^3.1.0",
     "webpack-dev-server": "^2.5.1",

--- a/src/scripts/webpack/webpack.build.js
+++ b/src/scripts/webpack/webpack.build.js
@@ -3,6 +3,7 @@ import path from 'path';
 import CompressionPlugin from 'compression-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import webpackFailPlugin from 'webpack-fail-plugin';
+import UglifyJsPlugin from 'uglifyjs-webpack-plugin';
 import WebpackBase from './webpack.base';
 
 export default ({ config, paths, NODE_ENV, ...options }) => {
@@ -21,13 +22,14 @@ export default ({ config, paths, NODE_ENV, ...options }) => {
       regExp: /\.js$|\.css$/
     }));
 
-    plugins.unshift(
-      new webpack.optimize.UglifyJsPlugin({
-        compress: { warnings: false, screw_ie8: true },
-        output: { comments: false },
-        sourceMap: true
-      })
-    );
+    plugins.unshift(new UglifyJsPlugin({
+      uglifyOptions: {
+        ecma: 8
+      },
+      parallel: true,
+      cache: true,
+      sourceMap: true
+    }));
   }
 
   return {


### PR DESCRIPTION
Closes #170

can be tested using npm `scriptoni@0.10.2-0`
(or `@buildo/bento@1.0.10-1`)

## Test Plan

### tests performed
tested on internal project
- reproduced error removing `ie11` from `.babelrc/env`
- no error with this update
- bundle sizes are exactly the same