### PR TITLE
#76: Webpack extendable configuration (closes #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,34 @@ t.interface({
 ```
 
 See https://github.com/buildo/webseed/tree/master/config for an example/minimal configuration.
+
+** custom Webpack config **
+
+The default webpack config shipped with scriptoni should be fine in most cases. However, you may need to change something.
+If this is the case, you can override the default config by passing an additional `--webpackConfig` argument, followed by the file path containing your override function.
+
+Let's say, for example, you want to change the output library.
+You can provide a `webpack.config.js` file in the root directory of your project, with the following content:
+
+```js
+module.exports = (defaultConfig, { config, paths, NODE_ENV, target }) => ({
+  ...defaultConfig,
+  output: {
+    ...config.output,
+    library: 'myclient'
+  }
+});
+```
+
+As you can see, your function will receive the default webpack config as first argument, followed by an object containing useful options:
+- `config`: the app config (see the previous chapter)
+- `paths`: the paths used by your project
+- `NODE_ENV`: 'development' or 'production'
+- `target`: one of `dev`, `build`, `dev-ts` or `build-ts`
+
+As a last step, you can change the `start` and `build` scripts in your `package.json` file by adding `--webpackConfig ./webpack.config.js` and the end of both commands:
+
+```json
+"start": "UV_THREADPOOL_SIZE=20 scriptoni web-dev -c ./config --webpackConfig ./webpack-config.js",
+"build": "UV_THREADPOOL_SIZE=20 scriptoni web-build -c ./config --webpackConfig ./webpack-config.js"
+```

--- a/src/scripts/webpack/build-ts.js
+++ b/src/scripts/webpack/build-ts.js
@@ -5,7 +5,7 @@ import { statsOutputConfiguration } from './util';
 
 const getBuildConfig = (options) => webpackBuild({ ...options, jsLoader: 'typescript' });
 
-compiler(getBuildConfig).run((err, stats) => {
+compiler(getBuildConfig, 'build-ts').run((err, stats) => {
   if (err) { throw err; }
   logger.webpack(stats.toString(statsOutputConfiguration));
 });

--- a/src/scripts/webpack/build.js
+++ b/src/scripts/webpack/build.js
@@ -3,7 +3,7 @@ import compiler from './compiler';
 import { logger } from '../../util';
 import { statsOutputConfiguration } from './util';
 
-compiler(webpackBuild).run((err, stats) => {
+compiler(webpackBuild, 'build').run((err, stats) => {
   if (err) { throw err; }
   logger.webpack(stats.toString(statsOutputConfiguration));
 });

--- a/src/scripts/webpack/compiler.js
+++ b/src/scripts/webpack/compiler.js
@@ -3,8 +3,10 @@ import minimist from 'minimist';
 import { logger } from '../../util';
 import getConfig from './config';
 import getPaths from './paths';
+import path from 'path';
+import identity from 'lodash/identity';
 
-export default function compiler(getWebpackConfig) {
+export default function compiler(getWebpackConfig, target) {
 
   const args = minimist(process.argv.slice(2));
 
@@ -12,12 +14,17 @@ export default function compiler(getWebpackConfig) {
 
   const paths = getPaths(args);
 
+  const customConfig = args.webpackConfig ? path.join(process.cwd(), args.webpackConfig) : undefined;
+  const customizeConfigFn = customConfig ? require(customConfig) : identity;
+
   logger.webpack('platform', process.platform);
   const NODE_ENV = process.env.NODE_ENV || config.NODE_ENV || 'development';
   logger.webpack('building with', `NODE_ENV=${NODE_ENV}`);
   logger.webpack('Configuration', JSON.stringify(config, null, 4));
 
-  const compiler = webpack(getWebpackConfig({ config, paths, NODE_ENV }));
+  const configArgs = { config, paths, NODE_ENV };
+  const webpackConfig = customizeConfigFn(getWebpackConfig(configArgs), { ...configArgs, target });
+  const compiler = webpack(webpackConfig);
 
   compiler.plugin('compile', () => {
     logger.webpack('Start compiling...');

--- a/src/scripts/webpack/dev-ts.js
+++ b/src/scripts/webpack/dev-ts.js
@@ -11,7 +11,7 @@ const getWebpackConfig = (options) => webpackConfig({ ...options, jsLoader: 'typ
 const args = minimist(process.argv.slice(2));
 const paths = getPaths(args);
 
-const server = new webpackServer(compiler(getWebpackConfig), {
+const server = new webpackServer(compiler(getWebpackConfig, 'dev-ts'), {
   contentBase: paths.BUILD,
   hot: true,
   stats: statsOutputConfiguration,

--- a/src/scripts/webpack/dev.js
+++ b/src/scripts/webpack/dev.js
@@ -9,7 +9,7 @@ import { statsOutputConfiguration } from './util';
 const args = minimist(process.argv.slice(2));
 const paths = getPaths(args);
 
-const server = new webpackServer(compiler(webpackConfig), {
+const server = new webpackServer(compiler(webpackConfig, 'dev'), {
   contentBase: paths.BUILD,
   hot: true,
   stats: statsOutputConfiguration,


### PR DESCRIPTION
Closes #76

## Test Plan

### tests performed
- Tested on banksealer with the following custom config file:
```js
module.exports = (config, { target }) => ({
  ...config,
  output: {
    ...config.output,
    library: target === 'dev' ? 'myclient' : 'yourclient'
  }
});
```
