### PR TITLE
#184: Webpack script: every path should be overwritable (closes #184)

### DIFF
--- a/src/scripts/webpack/paths.js
+++ b/src/scripts/webpack/paths.js
@@ -4,6 +4,7 @@ import { loadFileFromArgument } from '../../util';
 
 const Paths = t.interface({
   SRC: t.String,
+  ENTRY: t.String,
   LOCALES: t.String,
   THEME: t.String,
   THEME_FONTS: t.String,
@@ -12,26 +13,34 @@ const Paths = t.interface({
   NODE_MODULES: t.String,
   COMPONENTS: t.String,
   BASIC_COMPONENTS: t.String,
+  VIRTUAL_CONFIG: t.String,
+  TEMPLATE: t.String,
   VARIABLES_MATCH: t.Object // regex
 });
 
-const defaultPaths = {
-  SRC: path.resolve(process.cwd(), 'src'),
-  LOCALES: path.resolve(process.cwd(), 'src/locales'),
-  THEME: path.resolve(process.cwd(), 'src/theme'),
-  THEME_FONTS: path.resolve(process.cwd(), 'src/theme/fonts'),
-  BUILD: path.resolve(process.cwd(), 'build'),
-  ASSETS: path.resolve(process.cwd(), 'assets'),
-  NODE_MODULES: path.resolve(process.cwd(), 'node_modules'),
-  COMPONENTS: path.resolve(process.cwd(), 'src/components'),
-  BASIC_COMPONENTS: path.resolve(process.cwd(), 'src/components/Basic'),
-  VARIABLES_MATCH: /(v|V)ariables\.scss$/
-};
-
 export default function getPaths(args) {
+  const userPaths = loadFileFromArgument(args, 'paths', './paths.js') || {}
+  const ROOT = userPaths.ROOT || process.cwd();
+
   return Paths({
-    ...defaultPaths,
-    ...loadFileFromArgument(args, 'paths', './paths.js')
+    // defaultPaths
+    ROOT,
+    SRC: path.resolve(ROOT, 'src'),
+    ENTRY: path.resolve(ROOT, 'src/setup/index.js'),
+    LOCALES: path.resolve(ROOT, 'src/locales'),
+    THEME: path.resolve(ROOT, 'src/theme'),
+    THEME_FONTS: path.resolve(ROOT, 'src/theme/fonts'),
+    BUILD: path.resolve(ROOT, 'build'),
+    ASSETS: path.resolve(ROOT, 'assets'),
+    NODE_MODULES: path.resolve(ROOT, 'node_modules'),
+    COMPONENTS: path.resolve(ROOT, 'src/components'),
+    BASIC_COMPONENTS: path.resolve(ROOT, 'src/components/Basic'),
+    VIRTUAL_CONFIG: path.resolve(ROOT, 'src/config.json'),
+    TEMPLATE: path.resolve(ROOT, 'src/index.html'),
+    VARIABLES_MATCH: /(v|V)ariables\.scss$/,
+
+    // give priority to user custom paths
+    ...userPaths,
   });
 
 }

--- a/src/scripts/webpack/paths.js
+++ b/src/scripts/webpack/paths.js
@@ -3,6 +3,7 @@ import t from 'tcomb';
 import { loadFileFromArgument } from '../../util';
 
 const Paths = t.interface({
+  ROOT: t.String,
   SRC: t.String,
   ENTRY: t.String,
   LOCALES: t.String,

--- a/src/scripts/webpack/util.js
+++ b/src/scripts/webpack/util.js
@@ -1,11 +1,11 @@
 import path from 'path';
 
-export function getHtmlPluginConfig(NODE_ENV, config) {
+export function getHtmlPluginConfig(NODE_ENV, config, paths) {
   return {
     inject: false,
     bundle: NODE_ENV === 'production',
     minify: NODE_ENV === 'production' ? {} : false,
-    template: path.resolve(process.cwd(), './src/index.html'),
+    template: paths.TEMPLATE,
     title: config.title,
     data: config.bundle
   };

--- a/src/scripts/webpack/webpack.base.js
+++ b/src/scripts/webpack/webpack.base.js
@@ -35,7 +35,7 @@ export default ({ config, paths, NODE_ENV, jsLoader = JSLoader('babel') }) => {
 
     plugins: [
       new VirtualModulePlugin({
-        moduleName: path.resolve(process.cwd(), 'src/config.json'),
+        moduleName: paths.VIRTUAL_CONFIG,
         contents: JSON.stringify(config.bundle)
       }),
       new ProgressBarPlugin(),
@@ -48,7 +48,7 @@ export default ({ config, paths, NODE_ENV, jsLoader = JSLoader('babel') }) => {
         files: '**/*.scss',
         syntax: 'scss'
       }),
-      new HTMLPlugin(getHtmlPluginConfig(NODE_ENV, config))
+      new HTMLPlugin(getHtmlPluginConfig(NODE_ENV, config, paths))
     ],
 
     module: {

--- a/src/scripts/webpack/webpack.build.js
+++ b/src/scripts/webpack/webpack.build.js
@@ -40,7 +40,7 @@ export default ({ config, paths, NODE_ENV, ...options }) => {
 
     bail: true,
 
-    entry: path.resolve(paths.SRC, 'setup/index.js'),
+    entry: paths.ENTRY,
 
     devtool: 'source-map',
 

--- a/src/scripts/webpack/webpack.config.js
+++ b/src/scripts/webpack/webpack.config.js
@@ -10,7 +10,7 @@ export default ({ config, paths, NODE_ENV, ...options }) => {
     entry: [
       `webpack-dev-server/client?http://0.0.0.0:${config.port}/`,
       'webpack/hot/dev-server',
-      path.resolve(paths.SRC, 'setup/index.js')
+      paths.ENTRY
     ],
 
     devtool: config.devTool || 'source-map',


### PR DESCRIPTION
Closes #184

## Test Plan

### tests performed
tested on LabETA with this simple `paths.js` custom config:

```js
module.exports = {
  ROOT: __dirname
}
```

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
