### PR TITLE
#211: add prettier scripts (closes #211)

### DIFF
--- a/bin/scriptoni.js
+++ b/bin/scriptoni.js
@@ -72,6 +72,14 @@ switch (script) {
     clean();
     exit(spawnScript('webpack/build-ts'));
     break;
+  case 'prettier-write':
+    clean();
+    exit(spawnScript('prettier/write'));
+    break;
+  case 'prettier-check':
+    clean();
+    exit(spawnScript('prettier/listDifferent'));
+    break;
   default:
     console.log('Unknown script "' + script + '".');
     break;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "node-sass": "^4.5.2",
     "postcss": "^5.2.15",
     "postcss-scss": "^0.4.1",
+    "prettier": "^1.14.2",
     "progress": "^1.1.8",
     "progress-bar-webpack-plugin": "^1.10.0",
     "request": "^2.75.0",

--- a/src/copy-files.js
+++ b/src/copy-files.js
@@ -14,7 +14,8 @@ const copyToLib = (file) => {
 const files = [
   'eslint/eslintrc.json',
   'stylelint/stylelintrc.json',
-  'webpack/tsconfig.json'
+  'webpack/tsconfig.json',
+  'prettier/.prettierrc.js'
 ];
 
 files.map(copyToLib);

--- a/src/scripts/prettier/.prettierrc.js
+++ b/src/scripts/prettier/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  printWidth: 100,
+  parser: 'typescript',
+  singleQuote: true
+}

--- a/src/scripts/prettier/getCommandsAndDefaultArgs.js
+++ b/src/scripts/prettier/getCommandsAndDefaultArgs.js
@@ -1,0 +1,16 @@
+import path from 'path';
+
+const cwd = process.cwd();
+const command = path.resolve(cwd, 'node_modules', 'scriptoni', 'node_modules', 'prettier', 'bin-prettier.js');
+const configPath = path.join(__dirname, '.prettierrc.js');
+const files = '{**/*,*}.{js,jsx,ts,tsx}';
+
+export default function getCommandsAndDefaultArgs(writeOrListDifferent) {
+  return {
+    command,
+    defaultArgs: {
+      config: configPath,
+      [writeOrListDifferent]: files
+    }
+  };
+}

--- a/src/scripts/prettier/listDifferent.js
+++ b/src/scripts/prettier/listDifferent.js
@@ -1,0 +1,7 @@
+import execCommand from '../execCommand';
+import { logger } from '../../util';
+import getCommandAndDefaultArgs from './getCommandsAndDefaultArgs';
+
+const { command, defaultArgs } = getCommandAndDefaultArgs('list-different');
+
+execCommand(command, defaultArgs, logger.prettier);

--- a/src/scripts/prettier/write.js
+++ b/src/scripts/prettier/write.js
@@ -1,0 +1,7 @@
+import execCommand from '../execCommand';
+import { logger } from '../../util';
+import getCommandAndDefaultArgs from './getCommandsAndDefaultArgs';
+
+const { command, defaultArgs } = getCommandAndDefaultArgs('write');
+
+execCommand(command, defaultArgs, logger.prettier);

--- a/src/util.js
+++ b/src/util.js
@@ -15,5 +15,6 @@ export const logger = {
   metarpheusDiff: debug('scriptoni:metarpheus-diff'),
   lint: debug('scriptoni:lint'),
   lintStyle: debug('scriptoni:lint-style'),
-  webpack: debug('scriptoni:webpack')
+  webpack: debug('scriptoni:webpack'),
+  prettier: debug('scriptoni:prettier')
 };


### PR DESCRIPTION
Closes #211

## Test Plan

tested locally on a project, seems to do what we want. Didn't try to customize the config, but it should be doable either by overriding single params
```
scriptoni prettier-check --print-width 20
```
or by extending the default config
```
// myproject/.prettierrc.js
const baseConfig = require('scriptoni/lib/prettier/.prettierrc')
module.exports = {
   ...baseConfig,
  // customisations
}
```
and then providing the new config as a param to the script
```
scriptoni prettier-write --config ./prettierrc.js
```

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
