### PR TITLE
#216: more generic default entry in webpack (closes #216)

### DIFF
--- a/src/scripts/webpack/paths.js
+++ b/src/scripts/webpack/paths.js
@@ -28,7 +28,7 @@ export default function getPaths(args) {
     // defaultPaths
     ROOT,
     SRC: path.resolve(ROOT, 'src'),
-    ENTRY: path.resolve(ROOT, 'src/setup/index.js'),
+    ENTRY: path.resolve(ROOT, 'src/setup'),
     LOCALES: path.resolve(ROOT, 'src/locales'),
     THEME: path.resolve(ROOT, 'src/theme'),
     THEME_FONTS: path.resolve(ROOT, 'src/theme/fonts'),


### PR DESCRIPTION
Closes #216

## Test Plan

### tests performed
I tested the change on `bento/create-bento-app/template`. When running `yarn start` with the new entry everything works ok:
<img width="976" alt="screen shot 2018-09-03 at 14 40 59" src="https://user-images.githubusercontent.com/10383300/44987695-5a49d000-af88-11e8-8411-5b3127c95848.png">

and when I change the extension of the entry point to `.ts` everything breaks (obviously), but webpack still infer the correct entry point, `/setup/index.ts`:
<img width="976" alt="screen shot 2018-09-03 at 14 42 04" src="https://user-images.githubusercontent.com/10383300/44987765-a0069880-af88-11e8-8638-6b0b60a857c8.png">
 
