### PR TITLE
fix parsing of configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+.history

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ where:
 **`./config` directory**
 
 The `config` directory should include:
-- a `Config.js` file. It should export a `io-ts` type validating the configuration. Currently only `port` is strictly required by scriptoni webpack to work
+- a `Config.ts` file. It should export a `io-ts` type validating the configuration. Currently only `port` is strictly required by scriptoni webpack to work
 - any of `production.json`, `development.json`, `local.json` (all are optional): production and development should be tracked in version control, they are the default/base for `NODE_ENV=production` and `=development`, respectively. `local.json` is inteded to be used for custom, per-developer config tweaks, and should not be committed.
 
 The final configuration used to run webpack is obtained by merging `development.json` (`production.json` if `NODE_ENV=production`), `local.json` (which takes precedence) and (with maximum priority) environment variables corresponding to single config keys.
@@ -102,7 +102,7 @@ The virtual 'config' module obtained is available as `import config from 'config
 
 Not every config keys is actually part of the final bundle, In other words, not every config key is visible to TS code when importing from 'config'. The bundled configs should be specified as part of a sub-key `bundle`:
 ```js
-// config/Config.js
+// config/Config.ts
 t.interface({
   port: t.Integer,
   bundle: t.interface({

--- a/src/scripts/webpack/config.ts
+++ b/src/scripts/webpack/config.ts
@@ -56,9 +56,8 @@ export default function getWebpackOptions(options: WebpackCLIOptions): WebpackCo
 
   // get env variables configuration
   const topLevelKeys = Object.keys(omit(ConfigValidator.props, 'bundle'));
-  const bundleKeys =
-    ConfigValidator.props.bundle && typeof ConfigValidator.props.bundle.props === 'object'
-      ? Object.keys(ConfigValidator.props.bundle.props)
+  const bundleKeys = ConfigValidator.props && typeof ConfigValidator.props === 'object'
+      ? Object.keys(ConfigValidator.props)
       : [];
 
   // merge configurations in single object (env > local > reference)

--- a/src/scripts/webpack/config.ts
+++ b/src/scripts/webpack/config.ts
@@ -13,7 +13,7 @@ const getJSONConfiguration = (fullPath: string): { [k: string]: any } => {
 };
 
 const getConfigValidator = (configFolderPath: string): t.InterfaceType<any> => {
-  const configTypePath = path.resolve(configFolderPath, './Config.js');
+  const configTypePath = path.resolve(configFolderPath, './Config.ts');
 
   if (!fs.existsSync(configTypePath)) {
     throw new Error(`No Config type definition file found in ${configTypePath}`);
@@ -56,7 +56,8 @@ export default function getWebpackOptions(options: WebpackCLIOptions): WebpackCo
 
   // get env variables configuration
   const topLevelKeys = Object.keys(omit(ConfigValidator.props, 'bundle'));
-  const bundleKeys = ConfigValidator.props && typeof ConfigValidator.props === 'object'
+  const bundleKeys = 
+    ConfigValidator.props && typeof ConfigValidator.props === 'object'
       ? Object.keys(ConfigValidator.props)
       : [];
 


### PR DESCRIPTION
This fixes the validation of Config.js porting from `tcomb` to `io-ts`