### PR TITLE
#266 : Revert "#262: both scriptoni and VSCode ignore project's `.prettier.js` (closes #262)"

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/scripts/prettier/.prettierrc.js');

--- a/bin/scriptoni-ts.js
+++ b/bin/scriptoni-ts.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-require("ts-node/register");
-require("./scriptoni");
+require('ts-node/register');
+require('./scriptoni');

--- a/bin/scriptoni.js
+++ b/bin/scriptoni.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require("../lib");
+require('../lib');

--- a/copy-files.ts
+++ b/copy-files.ts
@@ -1,13 +1,10 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from 'fs';
+import * as path from 'path';
 
 const copyToLib = (file: string) => {
-  fs.writeFileSync(
-    path.resolve("lib", file),
-    fs.readFileSync(path.resolve("src", file))
-  );
+  fs.writeFileSync(path.resolve('lib', file), fs.readFileSync(path.resolve('src', file)));
 };
 
-const files = ["scripts/webpack/tsconfig.json"];
+const files = ['scripts/webpack/tsconfig.json', 'scripts/prettier/.prettierrc.js'];
 
 files.map(copyToLib);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,49 +1,44 @@
-import * as fs from "fs";
-import * as rimraf from "rimraf";
-import {
-  logger,
-  valueOrThrow,
-  getMetarpheusCLIOptions,
-  getWebpackCLIOptions
-} from "./util";
-import metarpheus from "./scripts/metarpheus";
-import metarpheusDiff from "./scripts/metarpheus-diff";
-import prettierWrite from "./scripts/prettier/write";
-import prettierCheck from "./scripts/prettier/listDifferent";
-import webpackDev from "./scripts/webpack/dev";
-import webpackBuild from "./scripts/webpack/build";
-import { Script } from "./model";
+import * as fs from 'fs';
+import * as rimraf from 'rimraf';
+import { logger, valueOrThrow, getMetarpheusCLIOptions, getWebpackCLIOptions } from './util';
+import metarpheus from './scripts/metarpheus';
+import metarpheusDiff from './scripts/metarpheus-diff';
+import prettierWrite from './scripts/prettier/write';
+import prettierCheck from './scripts/prettier/listDifferent';
+import webpackDev from './scripts/webpack/dev';
+import webpackBuild from './scripts/webpack/build';
+import { Script } from './model';
 
 const script = valueOrThrow(Script, process.argv[2]);
 
 function cleanBuildFolder() {
-  logger.bin("clean /build folder");
-  rimraf.sync("build");
-  fs.mkdirSync("build");
+  logger.bin('clean /build folder');
+  rimraf.sync('build');
+  fs.mkdirSync('build');
 }
 
 // default NODE_ENV for webpack scripts
-if (script === "web-build") {
-  process.env.NODE_ENV = process.env.NODE_ENV || "production";
-} else if (script === "web-dev") {
-  process.env.NODE_ENV = process.env.NODE_ENV || "development";
+if (script === 'web-build') {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+} else if (script === 'web-dev') {
+  process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 }
 
 function runScript(script: Script): Promise<void> {
   switch (script) {
-    case "metarpheus":
+    case 'metarpheus':
       return metarpheus(getMetarpheusCLIOptions());
-    case "metarpheus-diff":
+    case 'metarpheus-diff':
       return metarpheusDiff(getMetarpheusCLIOptions());
-    case "web-dev":
+    case 'web-dev':
       cleanBuildFolder();
       return webpackDev(getWebpackCLIOptions());
-    case "web-build":
+    case 'web-build':
       cleanBuildFolder();
       return webpackBuild(getWebpackCLIOptions());
-    case "prettier-write":
+    case 'prettier-write':
       return prettierWrite();
-    case "prettier-check":
+    case 'prettier-check':
       return prettierCheck();
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,13 +1,13 @@
-import * as webpack from "webpack";
-import * as t from "io-ts";
+import * as webpack from 'webpack';
+import * as t from 'io-ts';
 
 export const Script = t.union([
-  t.literal("metarpheus"),
-  t.literal("metarpheus-diff"),
-  t.literal("web-dev"),
-  t.literal("web-build"),
-  t.literal("prettier-check"),
-  t.literal("prettier-write")
+  t.literal('metarpheus'),
+  t.literal('metarpheus-diff'),
+  t.literal('web-dev'),
+  t.literal('web-build'),
+  t.literal('prettier-check'),
+  t.literal('prettier-write')
 ]);
 export type Script = t.TypeOf<typeof Script>;
 
@@ -51,9 +51,7 @@ export const WebpackConfigurationOptions = t.interface({
   devTool: t.union([t.undefined, DevTool]),
   bundle: t.dictionary(t.string, t.any)
 });
-export type WebpackConfigurationOptions = t.TypeOf<
-  typeof WebpackConfigurationOptions
->;
+export type WebpackConfigurationOptions = t.TypeOf<typeof WebpackConfigurationOptions>;
 
 export type WebpackConfiguration = webpack.Configuration & {
   plugins: webpack.Plugin[];
@@ -78,7 +76,7 @@ export type PartialMetarpheusConfig = t.TypeOf<typeof PartialMetarpheusConfig>;
 export const MetarpheusConfig = t.interface(metarpheusConfigProperties);
 export type MetarpheusConfig = t.TypeOf<typeof MetarpheusConfig>;
 
-export type MetarpheusOptions = Pick<MetarpheusConfig, "modelsForciblyInUse">;
+export type MetarpheusOptions = Pick<MetarpheusConfig, 'modelsForciblyInUse'>;
 
 export const Paths = t.interface({
   ROOT: t.string,
@@ -103,10 +101,10 @@ export type WebpackConfigBuilderInput = {
   config: WebpackConfigurationOptions;
   paths: Paths;
   NODE_ENV: string | undefined;
-  bundleAnalyzer: WebpackCLIOptions["bundleAnalyzer"];
+  bundleAnalyzer: WebpackCLIOptions['bundleAnalyzer'];
 };
 
 export type CustomizeFunction = (
   defaultConfiguration: WebpackConfiguration,
-  options: WebpackConfigBuilderInput & { target: "dev" | "build" }
+  options: WebpackConfigBuilderInput & { target: 'dev' | 'build' }
 ) => WebpackConfiguration;

--- a/src/scripts/prettier/.prettierrc.js
+++ b/src/scripts/prettier/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  printWidth: 100,
+  singleQuote: true
+};

--- a/src/scripts/prettier/getDefaultArgs.ts
+++ b/src/scripts/prettier/getDefaultArgs.ts
@@ -1,9 +1,13 @@
-const files = "**/*.{js,jsx,ts,tsx,scss}";
+import * as path from 'path';
+
+const configPath = path.join(__dirname, '.prettierrc.js');
+const files = '**/*.{js,jsx,ts,tsx,scss}';
 
 export default function getCommandsAndDefaultArgs(
-  writeOrListDifferent: "write" | "list-different"
+  writeOrListDifferent: 'write' | 'list-different'
 ) {
   return {
+    config: configPath,
     [writeOrListDifferent]: files
   };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,18 +1,18 @@
-import * as debug from "debug";
-import * as minimist from "minimist";
-import * as t from "io-ts";
-import { ThrowReporter } from "io-ts/lib/ThrowReporter";
-import { WebpackCLIOptions, MetarpheusCLIOptions } from "./model";
+import * as debug from 'debug';
+import * as minimist from 'minimist';
+import * as t from 'io-ts';
+import { ThrowReporter } from 'io-ts/lib/ThrowReporter';
+import { WebpackCLIOptions, MetarpheusCLIOptions } from './model';
 
-debug.enable("scriptoni:*");
+debug.enable('scriptoni:*');
 
 export const logger = {
-  bin: debug("scriptoni:bin"),
-  error: debug("scriptoni:error"),
-  metarpheus: debug("scriptoni:metarpheus"),
-  metarpheusDiff: debug("scriptoni:metarpheus-diff"),
-  webpack: debug("scriptoni:webpack"),
-  prettier: debug("scriptoni:prettier")
+  bin: debug('scriptoni:bin'),
+  error: debug('scriptoni:error'),
+  metarpheus: debug('scriptoni:metarpheus'),
+  metarpheusDiff: debug('scriptoni:metarpheus-diff'),
+  webpack: debug('scriptoni:webpack'),
+  prettier: debug('scriptoni:prettier')
 };
 
 export function valueOrThrow<O, I>(iotsType: t.Type<O, I>, value: I): O {
@@ -39,8 +39,8 @@ export const getMetarpheusCLIOptions = (): MetarpheusCLIOptions => {
 
 export const getWebpackCLIOptions = (): WebpackCLIOptions => {
   const defaultWebpackCLIOptions: WebpackCLIOptions = {
-    paths: "./paths.js",
-    c: "./config",
+    paths: './paths.js',
+    c: './config',
     webpackConfig: undefined,
     bundleAnalyzer: undefined
   };

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -1,21 +1,19 @@
-const resolve = require("path").resolve;
-const runCommands = require("./runCommands");
+const resolve = require('path').resolve;
+const runCommands = require('./runCommands');
 
-const scriptoniDir = resolve(__dirname, "..");
-const templateDir = resolve(__dirname, "template-app");
+const scriptoniDir = resolve(__dirname, '..');
+const templateDir = resolve(__dirname, 'template-app');
 
 module.exports = () => {
   console.log();
   console.log();
-  console.log("🕒 Preparing to run the tests! This will take a few minutes...");
-  console.log(
-    "🕒 Please be patient (or smart and improve `scriptoni/test/globalSetup.js`)"
-  );
+  console.log('🕒 Preparing to run the tests! This will take a few minutes...');
+  console.log('🕒 Please be patient (or smart and improve `scriptoni/test/globalSetup.js`)');
   console.log();
   return runCommands([
     `cd ${scriptoniDir}`,
-    "yarn build",
+    'yarn build',
     `cd ${templateDir}`,
-    "yarn --frozen-lockfile"
+    'yarn --frozen-lockfile'
   ]);
 };

--- a/test/metarpheus.test.ts
+++ b/test/metarpheus.test.ts
@@ -1,36 +1,32 @@
-import * as path from "path";
-import { runCommands, templateDir } from "./utils";
-import * as fs from "fs";
-import * as rimraf from "rimraf";
+import * as path from 'path';
+import { runCommands, templateDir } from './utils';
+import * as fs from 'fs';
+import * as rimraf from 'rimraf';
 
-const config = require("./template-app/metarpheus.config.test");
+const config = require('./template-app/metarpheus.config.test');
 
 const metarpheusDir = config.apiOut
-  .split("/")
+  .split('/')
   .slice(0, -1)
-  .join("/");
+  .join('/');
 const metarpheusOutPath = path.resolve(templateDir, metarpheusDir);
 
 afterAll(() => {
   rimraf.sync(metarpheusOutPath);
 });
 
-describe("metarpheus", () => {
-  describe("metarpheusConfig option", () => {
-    it("should read the correct config file", () => {
+describe('metarpheus', () => {
+  describe('metarpheusConfig option', () => {
+    it('should read the correct config file', () => {
       const apiPath = path.resolve(templateDir, config.apiOut);
       const modelsPath = path.resolve(templateDir, config.modelOut);
 
-      return runCommands([`cd ${templateDir}`, "yarn metarpheus"]).then(() => {
+      return runCommands([`cd ${templateDir}`, 'yarn metarpheus']).then(() => {
         expect(fs.existsSync(apiPath)).toBeTruthy();
         expect(fs.existsSync(modelsPath)).toBeTruthy();
 
-        expect(
-          fs.readFileSync(apiPath, { encoding: "utf8" })
-        ).toMatchSnapshot();
-        expect(
-          fs.readFileSync(modelsPath, { encoding: "utf8" })
-        ).toMatchSnapshot();
+        expect(fs.readFileSync(apiPath, { encoding: 'utf8' })).toMatchSnapshot();
+        expect(fs.readFileSync(modelsPath, { encoding: 'utf8' })).toMatchSnapshot();
       });
     });
   });

--- a/test/runCommands.js
+++ b/test/runCommands.js
@@ -1,16 +1,16 @@
-const spawn = require("child_process").spawn;
+const spawn = require('child_process').spawn;
 
-const isWin = process.platform === "win32";
+const isWin = process.platform === 'win32';
 
 module.exports = function runCommands(commands) {
   return new Promise((resolve, reject) => {
     try {
       const shell = spawn(
-        isWin ? "cmd" : "bash",
-        (isWin ? ["/c"] : ["-c"]).concat([commands.join(" && ")]),
-        { stdio: "inherit" }
+        isWin ? 'cmd' : 'bash',
+        (isWin ? ['/c'] : ['-c']).concat([commands.join(' && ')]),
+        { stdio: 'inherit' }
       );
-      shell.on("close", code => {
+      shell.on('close', code => {
         if (code === 1) {
           reject(1);
         } else {

--- a/test/template-app/src/components/App/App.tsx
+++ b/test/template-app/src/components/App/App.tsx
@@ -10,14 +10,14 @@ In this simple example it does a bit of both.
 
 */
 
-import * as React from "react";
-import View from "View";
-import SwitchViewDropdown from "SwitchViewDropdown";
-import Hello from "Hello";
-import { declareQueries } from "@buildo/bento/data";
-import { currentView } from "queries";
+import * as React from 'react';
+import View from 'View';
+import SwitchViewDropdown from 'SwitchViewDropdown';
+import Hello from 'Hello';
+import { declareQueries } from '@buildo/bento/data';
+import { currentView } from 'queries';
 
-import "./app.scss";
+import './app.scss';
 
 const queries = declareQueries({ currentView });
 
@@ -28,7 +28,7 @@ class App extends React.Component<typeof queries.Props> {
       <View column className="app">
         <h1>Bento App</h1>
         <SwitchViewDropdown />
-        {currentView.ready && currentView.value === "hello" && <Hello />}
+        {currentView.ready && currentView.value === 'hello' && <Hello />}
       </View>
     );
   }

--- a/test/template-app/src/components/Dropdown/dropdown.scss
+++ b/test/template-app/src/components/Dropdown/dropdown.scss
@@ -1,4 +1,4 @@
-@import "~theme/variables.scss";
+@import '~theme/variables.scss';
 
 $border-color-open: $azure;
 
@@ -6,4 +6,4 @@ $arrow-color: $coolGrey;
 $arrow-color-hover: $darkGrey;
 $arrow-color-open: $darkGrey;
 
-@import "~@buildo/bento/components/dropdown.scss";
+@import '~@buildo/bento/components/dropdown.scss';

--- a/test/template-app/src/components/Hello/Hello.tsx
+++ b/test/template-app/src/components/Hello/Hello.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
-import View from "View";
-import { FormattedMessage } from "react-intl";
-import { declareQueries } from "@buildo/bento/data";
-import { randomName } from "queries";
+import * as React from 'react';
+import View from 'View';
+import { FormattedMessage } from 'react-intl';
+import { declareQueries } from '@buildo/bento/data';
+import { randomName } from 'queries';
 
-import "./hello.scss";
+import './hello.scss';
 
 /*
 
@@ -48,7 +48,7 @@ type State = {
 
 export default class Hello extends React.Component<{}, State> {
   state = {
-    value: "10",
+    value: '10',
     length: 10,
     showError: false
   };
@@ -57,11 +57,10 @@ export default class Hello extends React.Component<{}, State> {
     const value = e.target.value;
     const parsedValue = parseInt(value);
 
-    const betweenSixAndFifty =
-      !isNaN(parsedValue) && parsedValue >= 6 && parsedValue <= 50;
+    const betweenSixAndFifty = !isNaN(parsedValue) && parsedValue >= 6 && parsedValue <= 50;
 
     if (!value) {
-      this.setState({ value: "" });
+      this.setState({ value: '' });
     } else if (betweenSixAndFifty) {
       this.setState({ value, length: parsedValue, showError: false });
     } else {

--- a/test/template-app/src/components/Hello/hello.scss
+++ b/test/template-app/src/components/Hello/hello.scss
@@ -1,4 +1,4 @@
-@import "~theme/variables.scss";
+@import '~theme/variables.scss';
 
 .hello {
   margin-top: 40px;

--- a/test/template-app/src/components/SwitchViewDropdown/SwitchViewDropdown.tsx
+++ b/test/template-app/src/components/SwitchViewDropdown/SwitchViewDropdown.tsx
@@ -9,13 +9,13 @@ using the dedicated query, command, helpers and types defined respecitvely in
 
 */
 
-import * as React from "react";
-import View from "components/View";
-import Dropdown from "components/Dropdown";
-import { declareQueries, declareCommands } from "@buildo/bento/data";
-import { viewToLocation, CurrentView } from "model";
-import { currentView } from "queries";
-import { doUpdateLocation } from "commands";
+import * as React from 'react';
+import View from 'components/View';
+import Dropdown from 'components/Dropdown';
+import { declareQueries, declareCommands } from '@buildo/bento/data';
+import { viewToLocation, CurrentView } from 'model';
+import { currentView } from 'queries';
+import { doUpdateLocation } from 'commands';
 
 const queries = declareQueries({ currentView });
 const commands = declareCommands({ doUpdateLocation });
@@ -24,12 +24,12 @@ type Props = typeof queries.Props & typeof commands.Props;
 
 const dropdownOptions = [
   {
-    value: "home",
-    label: "Home"
+    value: 'home',
+    label: 'Home'
   },
   {
-    value: "hello",
-    label: "Hello"
+    value: 'hello',
+    label: 'Hello'
   }
 ];
 
@@ -43,11 +43,7 @@ class SwitchViewDropdown extends React.Component<Props> {
     const value = currentView.ready ? currentView.value : undefined;
     return (
       <View className="switch-view-dropdown">
-        <Dropdown
-          options={dropdownOptions}
-          value={value}
-          onChange={this.onChange as any}
-        />
+        <Dropdown options={dropdownOptions} value={value} onChange={this.onChange as any} />
       </View>
     );
   }

--- a/test/template-app/src/theme/main.scss
+++ b/test/template-app/src/theme/main.scss
@@ -1,4 +1,4 @@
-@import "./variables.scss";
+@import './variables.scss';
 
 // THEME
 .layout,

--- a/test/template-app/src/theme/typography.scss
+++ b/test/template-app/src/theme/typography.scss
@@ -1,8 +1,8 @@
-@import "./variables.scss";
+@import './variables.scss';
 @import url(https://fonts.googleapis.com/css?family=Roboto);
 
 html {
-  font-family: "Source Sans Pro", sans-serif;
+  font-family: 'Source Sans Pro', sans-serif;
   font-size: 14px;
   font-weight: $regular;
   color: $black;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,8 +1,8 @@
-import { resolve } from "path";
+import { resolve } from 'path';
 
-const _runCommands = require("./runCommands");
+const _runCommands = require('./runCommands');
 
-export const templateDir = resolve(__dirname, "template-app");
+export const templateDir = resolve(__dirname, 'template-app');
 
 export function runCommands(commands: string[]): Promise<0> {
   return _runCommands(commands);

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -1,40 +1,36 @@
-import * as rimraf from "rimraf";
-import { resolve } from "path";
-import { promisify } from "util";
-import { readdir as _readdir, statSync, mkdirSync } from "fs";
-import sortBy = require("lodash/sortBy");
-import { runCommands, templateDir } from "./utils";
+import * as rimraf from 'rimraf';
+import { resolve } from 'path';
+import { promisify } from 'util';
+import { readdir as _readdir, statSync, mkdirSync } from 'fs';
+import sortBy = require('lodash/sortBy');
+import { runCommands, templateDir } from './utils';
 
 const readdir = promisify(_readdir);
 
-const stripHash = (fileName: string) =>
-  fileName.replace(/\.[\da-z]{20,}\./, ".");
+const stripHash = (fileName: string) => fileName.replace(/\.[\da-z]{20,}\./, '.');
 
 jest.setTimeout(10 * 60 * 1000);
 
-describe("webpack", () => {
-  describe("build", () => {
+describe('webpack', () => {
+  describe('build', () => {
     beforeAll(() => {
-      rimraf.sync(resolve(templateDir, "build"));
-      mkdirSync(resolve(templateDir, "build"));
-      return runCommands([`cd ${templateDir}`, "yarn build"]);
+      rimraf.sync(resolve(templateDir, 'build'));
+      mkdirSync(resolve(templateDir, 'build'));
+      return runCommands([`cd ${templateDir}`, 'yarn build']);
     });
 
-    it("built files should stay the same", async () => {
-      const fileNames = await readdir(resolve(templateDir, "build"));
+    it('built files should stay the same', async () => {
+      const fileNames = await readdir(resolve(templateDir, 'build'));
       expect(fileNames.map(stripHash)).toMatchSnapshot();
     });
 
-    it("built files should not change size", async () => {
-      const fileNames = await readdir(resolve(templateDir, "build"));
+    it('built files should not change size', async () => {
+      const fileNames = await readdir(resolve(templateDir, 'build'));
       const fileSizes = fileNames.map(name => ({
         name: stripHash(name),
-        size:
-          Math.floor(
-            statSync(resolve(templateDir, "build", name)).size / 1000
-          ) * 1000
+        size: Math.floor(statSync(resolve(templateDir, 'build', name)).size / 1000) * 1000
       }));
-      expect(sortBy(fileSizes, "name")).toMatchSnapshot();
+      expect(sortBy(fileSizes, 'name')).toMatchSnapshot();
     });
   });
 });

--- a/typings/metarpheus.d.ts
+++ b/typings/metarpheus.d.ts
@@ -1,1 +1,1 @@
-declare module "metarpheus";
+declare module 'metarpheus';

--- a/typings/progress-bar-webpack-plugin.d.ts
+++ b/typings/progress-bar-webpack-plugin.d.ts
@@ -1,1 +1,1 @@
-declare module "progress-bar-webpack-plugin";
+declare module 'progress-bar-webpack-plugin';

--- a/typings/virtual-module-webpack-plugin.d.ts
+++ b/typings/virtual-module-webpack-plugin.d.ts
@@ -1,1 +1,1 @@
-declare module "virtual-module-webpack-plugin";
+declare module 'virtual-module-webpack-plugin';


### PR DESCRIPTION
Reverts buildo/scriptoni#263

we figured it wasn't really the case