### PR TITLE
Updating some dependencies to fix GH and npm security advisories (Closes #278)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/debug": "^0.0.31",
     "@types/diff": "^3.5.2",
     "@types/html-webpack-plugin": "^3.2.0",
-    "@types/jest": "^22.2.3",
+    "@types/jest": "^24.0.18",
     "@types/lodash": "^4.14.118",
     "@types/mini-css-extract-plugin": "^0.2.0",
     "@types/minimist": "^1.2.0",
@@ -51,11 +51,11 @@
     "@types/uglifyjs-webpack-plugin": "^1.1.0",
     "@types/webpack": "^4.4.19",
     "@types/webpack-bundle-analyzer": "^2.13.0",
-    "@types/webpack-dev-server": "^3.1.1",
+    "@types/webpack-dev-server": "^3.1.7",
     "@types/webpack-fail-plugin": "^1.0.7",
-    "jest": "^23.5.0",
+    "jest": "^24.9.0",
     "smooth-release": "^8.0.0",
-    "ts-jest": "^22.4.6"
+    "ts-jest": "^24.1.0"
   },
   "dependencies": {
     "babel-cli": "^6.26.0",
@@ -64,7 +64,7 @@
     "babel-preset-buildo": "^0.1.1",
     "chalk": "^2.4.1",
     "compression-webpack-plugin": "^1.1.11",
-    "css-loader": "^0.28.4",
+    "css-loader": "^3.2.0",
     "debug": "^2.2.0",
     "diff": "^3.0.1",
     "file-loader": "^1.1.11",
@@ -96,7 +96,7 @@
     "virtual-module-webpack-plugin": "^0.4.0",
     "webpack": "^4.7.0",
     "webpack-bundle-analyzer": "^3.0.2",
-    "webpack-dev-server": "^3.1.4",
+    "webpack-dev-server": "^3.8.1",
     "webpack-fail-plugin": "^2.0.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "html-webpack-plugin": "^3.2.0",
     "io-ts": "^1.10.4",
     "metarpheus": "^1.3.5",
-    "metarpheus-io-ts": "^1.0.0",
+    "metarpheus-io-ts": "^1.0.3",
     "mini-css-extract-plugin": "^0.4.2",
     "minimist": "^1.2.0",
     "node-glob": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mini-css-extract-plugin": "^0.4.2",
     "minimist": "^1.2.0",
     "node-glob": "^1.2.0",
-    "node-sass": "^4.5.2",
+    "node-sass": "^4.12.0",
     "postcss": "^5.2.15",
     "postcss-scss": "^0.4.1",
     "prettier": "^1.14.2",

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -40,7 +40,7 @@ Array [
   },
   Object {
     "name": "main.style.min.css",
-    "size": 10000,
+    "size": 8000,
   },
   Object {
     "name": "main.style.min.css.gz",
@@ -48,11 +48,11 @@ Array [
   },
   Object {
     "name": "vendors~main.bundle.js",
-    "size": 664000,
+    "size": 671000,
   },
   Object {
     "name": "vendors~main.bundle.js.gz",
-    "size": 176000,
+    "size": 178000,
   },
   Object {
     "name": "vendors~main.style.min.css",


### PR DESCRIPTION
Closes [#2521025](https://buildo.kaiten.io/space/[object Object]/card/2521025)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #278