### PR TITLE
#285: [webpack] DevTools failed to parse SourceMap Warning (closes #285)

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,7 +31,7 @@ jobs:
         type: docker-image
         source:
           repository: node
-          tag: 8
+          tag: 12
       inputs:
         - name: scriptoni
       caches:

--- a/src/scripts/webpack/config.ts
+++ b/src/scripts/webpack/config.ts
@@ -78,7 +78,7 @@ export default function getWebpackOptions(options: WebpackCLIOptions): WebpackCo
 
   const defaultConfig: Partial<WebpackConfigurationOptions> = {
     port: 3000,
-    devTool: 'eval-source-map',
+    devTool: 'cheap-eval-source-map'
   };
 
   // validate against scriptoni's validator

--- a/src/scripts/webpack/config.ts
+++ b/src/scripts/webpack/config.ts
@@ -77,7 +77,8 @@ export default function getWebpackOptions(options: WebpackCLIOptions): WebpackCo
   valueOrThrow(ConfigValidator, config);
 
   const defaultConfig: Partial<WebpackConfigurationOptions> = {
-    port: 3000
+    port: 3000,
+    devTool: 'eval-source-map',
   };
 
   // validate against scriptoni's validator


### PR DESCRIPTION
Closes [#2520302](https://buildo.kaiten.io/space/32111/card/2520302)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #285

## Test Plan

### local test
Project build with no devTools config:
![image](https://user-images.githubusercontent.com/32327779/79197872-d24dcc80-7e32-11ea-83d0-034b3d60b616.png)

Project build with devTool: cheap-eval-source-map
![image](https://user-images.githubusercontent.com/32327779/79198037-1a6cef00-7e33-11ea-9b6e-dbb58eee231d.png)
