### PR TITLE
#290: Use updated metarpheus-io-ts for fp-ts v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "html-webpack-plugin": "^3.2.0",
     "io-ts": "^1.10.4",
     "metarpheus": "^2.1.0",
-    "metarpheus-io-ts": "^1.0.5",
+    "metarpheus-io-ts": "^2.0.0-1",
     "mini-css-extract-plugin": "^0.4.2",
     "minimist": "^1.2.0",
     "node-glob": "^1.2.0",


### PR DESCRIPTION
Closes [#2520340](https://buildo.kaiten.io/space/32111/card/2520340)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #290

Opening against a branch `v10` so we can publish a premajor version v10.0.0-0 to test it.

## Test Plan

Tested by generating models on internal projects. It looks fine. More testing will be done on the published premajor version.