### PR TITLE
#293: Fix failing tests in v10

### DIFF
--- a/test/__snapshots__/metarpheus.test.ts.snap
+++ b/test/__snapshots__/metarpheus.test.ts.snap
@@ -14,7 +14,7 @@ exports[`metarpheus metarpheusConfig option should read the correct config file 
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
 // @ts-ignore
-import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+import { optionFromNullable } from 'io-ts-types/lib/optionFromNullable'
 // @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
@@ -35,7 +35,7 @@ export interface Account {
 export const Account = t.type({
   id: t.string,
   username: t.string,
-  email: createOptionFromNullable(t.string),
+  email: optionFromNullable(t.string),
   publicKey: t.string
 }, 'Account')"
 `;

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -32,7 +32,7 @@ Array [
   },
   Object {
     "name": "main.bundle.js",
-    "size": 13000,
+    "size": 12000,
   },
   Object {
     "name": "main.bundle.js.gz",
@@ -48,11 +48,11 @@ Array [
   },
   Object {
     "name": "vendors~main.bundle.js",
-    "size": 671000,
+    "size": 679000,
   },
   Object {
     "name": "vendors~main.bundle.js.gz",
-    "size": 177000,
+    "size": 180000,
   },
   Object {
     "name": "vendors~main.style.min.css",


### PR DESCRIPTION
Closes [#2520339](https://buildo.kaiten.io/space/32111/card/2520339)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #293

Fix broken tests on v10.

## Test Plan

Now `yarn test` runs correctly locally (previously I had an unrelated problem and hadn't noticed the tests were really failing).

Still broken on CI (tracked in separate issue).