### PR TITLE
#292: Update node version in CI and fix ensuing errors

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -35,7 +35,7 @@ jobs:
         type: docker-image
         source:
           repository: node
-          tag: 8
+          tag: "15.10"
       inputs:
         - name: scriptoni
       caches:

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -32,7 +32,7 @@ Array [
   },
   Object {
     "name": "main.bundle.js",
-    "size": 13000,
+    "size": 12000,
   },
   Object {
     "name": "main.bundle.js.gz",
@@ -48,11 +48,11 @@ Array [
   },
   Object {
     "name": "vendors~main.bundle.js",
-    "size": 671000,
+    "size": 680000,
   },
   Object {
     "name": "vendors~main.bundle.js.gz",
-    "size": 177000,
+    "size": 180000,
   },
   Object {
     "name": "vendors~main.style.min.css",

--- a/test/globalSetup.js
+++ b/test/globalSetup.js
@@ -14,7 +14,7 @@ module.exports = () => {
     `cd ${scriptoniDir}`,
     'yarn build',
     `cd ${__dirname}`,
-    'npx @buildo/create-bento-app test-app',
+    'npm_config_yes=true npx @buildo/create-bento-app test-app',
     'cd test-app',
     `cp -a ${templateFilesDir}/. .`,
     'yarn remove scriptoni',


### PR DESCRIPTION
Closes [#2520334](https://buildo.kaiten.io/space/32111/card/2520334)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #292

- Update node version in CI to 15.10
- Change `npx` command in the test script to skip the confirmation prompt introduced in newer versions
- Update snapshots

The pipeline change has already been applied.

Note: this targets `master`, but we also have the `v10` branch which is active so it should be merged there too (merging `master` into `v10`?).

## Test Plan

The tests now run correctly both locally and on CI.